### PR TITLE
fix: raise iOS deployment target to 16.0 to match HealthKit API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Raised the iOS deployment target from 13.0 to 16.0. The Swift sources use
+  `HKCategoryValueSleepAnalysis.asleepUnspecified` (iOS 16+) and
+  `HKWorkoutActivityType.dance` (iOS 14+), so the previous 13.0 floor never
+  actually compiled. The podspec and README now reflect the real minimum
+  (fixes #3).
+
 ## [1.0.0] - 2025-11-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A unified React Native interface for accessing health data from both **Android H
 ## Requirements
 
 - React Native >= 0.70
-- iOS 13.0+
+- iOS 16.0+
 - Android API 28+ (Android 9+)
   - **Android 14+**: Health Connect is built into the framework (no setup needed)
   - **Android 9-13**: Health Connect app must be installed from Play Store

--- a/react-native-health-kits.podspec
+++ b/react-native-health-kits.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "13.0" }
+  s.platforms    = { :ios => "16.0" }
   s.source       = { :git => "https://github.com/dayaki/react-native-health-kits.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
Closes #3

## Problem

The podspec declared `s.platforms = { :ios => "13.0" }`, but the Swift sources reference HealthKit APIs that require a newer iOS:

- `HKCategoryValueSleepAnalysis.asleepUnspecified` — **iOS 16.0+** (`ios/HealthKits.swift`, sleep write)
- `HKWorkoutActivityType.dance` — **iOS 14.0+** (`ios/HealthKits.swift`, workout write)

Referencing an API above the deployment target is a **hard compile error** in Swift, not a warning — so the pod never actually built at 13.0. Consumers had to patch the podspec to get it to compile (as reported in #3, via `patch-package`).

## Fix

Raise the deployment target to the real minimum the code requires:

- `react-native-health-kits.podspec`: `:ios => "13.0"` → `"16.0"` (matches the patch in #3)
- `README.md`: Requirements `iOS 13.0+` → `iOS 16.0+`
- `CHANGELOG.md`: documented under Unreleased

No Swift changes are needed — bumping to 16.0 covers both the iOS 16 sleep API and the iOS 14 workout type.

## Notes

iOS 16 was released Sept 2022; in practice nearly all active devices are on 16+. Keeping a lower floor (e.g. 14.0) would have been possible by wrapping `asleepUnspecified` in an `if #available(iOS 16.0, *)` guard with an `.asleep` fallback, but the simpler 16.0 bump was chosen here.

## Testing

- [ ] `pod install` succeeds in a consuming app at iOS 16.0
- [ ] Sleep write and workout write build/run on device
