### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for react-native-health-kits
+# These owners are automatically requested for review and are the
+# required reviewers on protected branches.
+#
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo
+* @dayaki


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @dayaki` so @dayaki is the default owner of all paths.

Combined with the branch protection rule on `main` (require a PR + 1 approval, with *require review from code owners* enabled), this makes @dayaki the required reviewer on every PR.

Note: this file only takes effect once it's merged into the default branch.