### PR TITLE
feat!: convert to a true Turbo Native Module (New Architecture only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- **BREAKING:** Converted to a true Turbo Native Module and dropped legacy-bridge
+  support. The library now requires the **New Architecture** (bridgeless) and
+  **React Native >= 0.76**.
+  - iOS: the module binds to the codegen spec via `getTurboModule`
+    (`HealthKits.m` → `HealthKits.mm`); the Swift implementation is unchanged.
+  - Android: `HealthKitsModule` now extends the generated `NativeHealthKitsSpec`
+    and `HealthKitsPackage` extends `BaseReactPackage`.
+  - This fixes the `TurboModuleRegistry.getEnforcing('HealthKits') could not be
+    found` error caused by the previous legacy-module/TurboModule-spec mismatch
+    (#1).
+
 ## [1.0.0] - 2025-11-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A unified React Native interface for accessing health data from both **Android H
 
 ## Requirements
 
-- React Native >= 0.70
+- React Native >= 0.76
+- **New Architecture (bridgeless) required** — this library ships as a Turbo Native Module. It must be used in an app with the New Architecture enabled (the default since React Native 0.76). It will not load on the old/legacy bridge.
 - iOS 13.0+
 - Android API 28+ (Android 9+)
   - **Android 14+**: Health Connect is built into the framework (no setup needed)
@@ -278,6 +279,16 @@ try {
 ```
 
 ## Troubleshooting
+
+### `TurboModuleRegistry.getEnforcing('HealthKits') could not be found`
+
+This means the native module isn't compiled into the app. Check, in order:
+
+1. **New Architecture is enabled.** This is a Turbo Native Module and requires the New Architecture (default in RN 0.76+). iOS: `RCT_NEW_ARCH_ENABLED=1`. Android: `newArchEnabled=true` in `gradle.properties`.
+2. **You rebuilt the native app, not just reloaded JS.** Native changes need a full rebuild — `npx react-native run-ios` / `run-android`, or build from Xcode/Android Studio. A Metro reload is not enough.
+3. **iOS pods are installed:** `cd ios && pod install` after adding the package (or `RCT_NEW_ARCH_ENABLED=1 pod install`).
+4. **Metro cache is clear:** `npx react-native start --reset-cache`.
+5. **You are not running in Expo Go**, which can't load custom native modules — use a development build / `expo prebuild`.
 
 ### iOS
 

--- a/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsModule.kt
+++ b/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsModule.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 
 @ReactModule(name = HealthKitsModule.NAME)
 class HealthKitsModule(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext) {
+    NativeHealthKitsSpec(reactContext) {
 
     companion object {
         const val NAME = "HealthKits"
@@ -48,14 +48,12 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         return healthConnectClient
     }
 
-    @ReactMethod
-    fun isAvailable(promise: Promise) {
+    override fun isAvailable(promise: Promise) {
         val availability = HealthConnectClient.getSdkStatus(reactApplicationContext)
         promise.resolve(availability == HealthConnectClient.SDK_AVAILABLE)
     }
 
-    @ReactMethod
-    fun requestPermissions(permissionsJson: String, promise: Promise) {
+    override fun requestPermissions(permissionsJson: String, promise: Promise) {
         scope.launch {
             try {
                 val client = getHealthConnectClient()
@@ -97,8 +95,7 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun getPermissionStatus(dataType: String, accessType: String, promise: Promise) {
+    override fun getPermissionStatus(dataType: String, accessType: String, promise: Promise) {
         scope.launch {
             try {
                 val client = getHealthConnectClient()
@@ -125,8 +122,7 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun readData(optionsJson: String, promise: Promise) {
+    override fun readData(optionsJson: String, promise: Promise) {
         scope.launch {
             try {
                 val client = getHealthConnectClient()
@@ -172,8 +168,7 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun writeData(dataJson: String, promise: Promise) {
+    override fun writeData(dataJson: String, promise: Promise) {
         scope.launch {
             try {
                 val client = getHealthConnectClient()
@@ -206,8 +201,7 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun subscribeToUpdates(dataType: String, promise: Promise) {
+    override fun subscribeToUpdates(dataType: String, promise: Promise) {
         scope.launch {
             try {
                 val client = getHealthConnectClient()
@@ -236,14 +230,12 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun unsubscribeFromUpdates(subscriptionId: String, promise: Promise) {
+    override fun unsubscribeFromUpdates(subscriptionId: String, promise: Promise) {
         changesTokens.remove(subscriptionId)
         promise.resolve(null)
     }
 
-    @ReactMethod
-    fun openHealthConnectSettings(promise: Promise) {
+    override fun openHealthConnectSettings(promise: Promise) {
         try {
             val intent = Intent(Intent.ACTION_VIEW).apply {
                 data = Uri.parse("healthconnect://settings")
@@ -266,13 +258,11 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    @ReactMethod
-    fun addListener(eventName: String) {
+    override fun addListener(eventName: String) {
         // Required for RN event emitter
     }
 
-    @ReactMethod
-    fun removeListeners(count: Int) {
+    override fun removeListeners(count: Double) {
         // Required for RN event emitter
     }
 

--- a/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsPackage.kt
+++ b/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsPackage.kt
@@ -1,12 +1,12 @@
 package com.dayaki.reactnativehealthkits
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class HealthKitsPackage : TurboReactPackage() {
+class HealthKitsPackage : BaseReactPackage() {
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
         return if (name == HealthKitsModule.NAME) {
             HealthKitsModule(reactContext)
@@ -23,7 +23,6 @@ class HealthKitsPackage : TurboReactPackage() {
                 HealthKitsModule.NAME,
                 false,  // canOverrideExistingModule
                 false,  // needsEagerInit
-                true,   // hasConstants
                 false,  // isCxxModule
                 true    // isTurboModule
             )

--- a/ios/HealthKits.mm
+++ b/ios/HealthKits.mm
@@ -1,6 +1,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 
+// Method export for the Swift `HealthKits` class. The actual implementations
+// live in HealthKits.swift; these declarations expose them to React Native.
 @interface RCT_EXTERN_MODULE(HealthKits, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve
@@ -35,3 +37,23 @@ RCT_EXTERN_METHOD(openHealthConnectSettings:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 @end
+
+// New Architecture: bind the module to the codegen-generated TurboModule spec.
+// `RNHealthKitsSpec` is codegenConfig.name; the generated protocol/JSI class are
+// derived from the spec file name (NativeHealthKits.ts -> NativeHealthKitsSpec).
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNHealthKitsSpec/RNHealthKitsSpec.h>
+
+@interface HealthKits (TurboModule) <NativeHealthKitsSpec>
+@end
+
+@implementation HealthKits (TurboModule)
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeHealthKitsSpecJSI>(params);
+}
+
+@end
+#endif

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": ">=18.0.0",
-    "react-native": ">=0.70.0"
+    "react-native": ">=0.76.0"
   },
   "workspaces": [
     "example"
@@ -88,6 +88,11 @@
     "name": "RNHealthKitsSpec",
     "type": "modules",
     "jsSrcsDir": "src",
+    "ios": {
+      "modulesProvider": {
+        "HealthKits": "HealthKits"
+      }
+    },
     "android": {
       "javaPackageName": "com.dayaki.reactnativehealthkits"
     }


### PR DESCRIPTION
Fixes #1

Converts the library from a legacy bridge module (which shipped behind a TurboModule JS spec and only resolved via new-arch interop) into a **true Turbo Native Module**. This resolves `TurboModuleRegistry.getEnforcing('HealthKits') could not be found`.

## Changes
- **iOS:** `HealthKits.m` → `HealthKits.mm`; binds to the codegen spec via `getTurboModule` returning `NativeHealthKitsSpecJSI` under `RCT_NEW_ARCH_ENABLED`. Swift implementation unchanged. Added `codegenConfig.ios.modulesProvider`.
- **Android:** `HealthKitsModule` extends the generated `NativeHealthKitsSpec` (spec methods are now `override`; `removeListeners` takes `Double`); `HealthKitsPackage` extends `BaseReactPackage` with the 6-arg `ReactModuleInfo`.
- **Compat:** drops legacy-bridge support — requires the New Architecture and React Native >= 0.76.
- **Docs:** README new-arch requirement + a "TurboModule not found" troubleshooting section; CHANGELOG entry.

## ⚠️ Draft — needs on-device build verification
Not yet compiled on either platform. Likely iteration points:
1. **iOS (highest risk):** `HealthKits` is an `RCTEventEmitter` *and* now a TurboModule via a category. The `<NativeHealthKitsSpec>` conformance may emit "method not implemented" warnings (impls are in Swift); if so, drop the explicit conformance and keep only `getTurboModule`. Run `RCT_NEW_ARCH_ENABLED=1 pod install` so codegen generates the spec header first.
2. **Android `ReactModuleInfo` arity:** uses the 6-arg form (no `hasConstants`), correct for 0.76+.
3. Run codegen before judging build errors (`pod install` / `generateCodegenArtifactsFromSchema`).

## Breaking change
Requires the New Architecture and React Native >= 0.76. Should ship as a major (2.0.0).