### PR TITLE
feat: cross-platform aggregation parity for cumulative types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Android: `readData` now honors `aggregate` / `aggregateInterval` using Health
+  Connect's aggregate APIs (`aggregateGroupByPeriod` for day/week/month,
+  `aggregateGroupByDuration` for hour), reaching parity with iOS.
+
+### Fixed
+- Aggregation is now restricted to cumulative types (`steps`, `distance`,
+  `activeCalories`, `totalCalories`, `floorsClimbed`, `hydration`) on both
+  platforms. Previously iOS silently summed instantaneous types (e.g.
+  `heartRate`, `weight`), and Android ignored `aggregate` entirely. Unsupported
+  types now reject with `UNSUPPORTED_DATA_TYPE`.
+
 ## [1.0.0] - 2025-11-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ const dailySteps = await HealthKits.readData({
 });
 ```
 
+> **Aggregation is for cumulative types only.** `aggregate` produces a
+> cumulative sum per interval, which is only meaningful for **`steps`,
+> `distance`, `activeCalories`, `totalCalories`, `floorsClimbed`, and
+> `hydration`**. Requesting it for any other (instantaneous) type — e.g.
+> `heartRate`, `weight`, `bloodGlucose` — rejects with `UNSUPPORTED_DATA_TYPE`.
+> Read those as raw records and aggregate in app code instead.
+>
+> This behaves the same on iOS (HealthKit `HKStatisticsCollectionQuery`) and
+> Android (Health Connect `aggregateGroupByPeriod` / `aggregateGroupByDuration`).
+>
+> **For sync/storage, don't store aggregated results.** They are derived and
+> synthetic — each query assigns a generated `id` and an `"aggregated"` source,
+> so they have no stable identity and can't be deduplicated. Persist raw
+> provider records as your source of truth and aggregate at read time.
+
 ### Reading Sleep Data
 
 ```typescript
@@ -194,7 +209,9 @@ interface ReadOptions {
   startDate: Date | string;
   endDate: Date | string;
   limit?: number;
+  /** Cumulative types only (steps, distance, activeCalories, totalCalories, floorsClimbed, hydration). */
   aggregate?: boolean;
+  /** Defaults to 'day'. */
   aggregateInterval?: 'hour' | 'day' | 'week' | 'month';
 }
 ```

--- a/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsModule.kt
+++ b/android/src/main/java/com/dayaki/reactnativehealthkits/HealthKitsModule.kt
@@ -4,10 +4,14 @@ import android.content.Intent
 import android.net.Uri
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
+import androidx.health.connect.client.aggregate.AggregateMetric
+import androidx.health.connect.client.aggregate.AggregationResult
 import androidx.health.connect.client.changes.Change
 import androidx.health.connect.client.changes.UpsertionChange
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.*
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.ChangesTokenRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
@@ -18,8 +22,13 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import kotlinx.coroutines.*
 import org.json.JSONArray
 import org.json.JSONObject
+import java.time.Duration
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.util.UUID
 import kotlin.reflect.KClass
 
 @ReactModule(name = HealthKitsModule.NAME)
@@ -140,6 +149,25 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
                 val startDate = Instant.parse(options.getString("startDate"))
                 val endDate = Instant.parse(options.getString("endDate"))
                 val limit = options.optInt("limit", 1000)
+                val aggregate = options.optBoolean("aggregate", false)
+
+                // Aggregation is a read-time convenience for cumulative metrics only.
+                // Sleep/workout are session types and fall through to their raw readers,
+                // mirroring the iOS behaviour.
+                if (aggregate && type != "sleep" && type != "workout") {
+                    if (!isCumulativeType(type)) {
+                        promise.reject(
+                            "UNSUPPORTED_DATA_TYPE",
+                            "Aggregation is only supported for cumulative types " +
+                                "(steps, distance, activeCalories, totalCalories, floorsClimbed, hydration). " +
+                                "'$type' is not a cumulative type; read raw records and aggregate in app code, or omit `aggregate`."
+                        )
+                        return@launch
+                    }
+                    val interval = options.optString("aggregateInterval", "day")
+                    promise.resolve(readAggregatedData(client, type, startDate, endDate, interval).toString())
+                    return@launch
+                }
 
                 val results = when (type) {
                     "steps" -> readSteps(client, startDate, endDate, limit)
@@ -327,6 +355,123 @@ class HealthKitsModule(reactContext: ReactApplicationContext) :
             "nutrition" -> NutritionRecord::class
             else -> null
         }
+    }
+
+    // Aggregation
+
+    /**
+     * Aggregation (cumulative sum per interval) only has a well-defined meaning for
+     * cumulative quantity types. Instantaneous types (heart rate, weight, blood
+     * glucose, etc.) must be read as raw records instead.
+     */
+    private fun isCumulativeType(type: String): Boolean = when (type) {
+        "steps", "distance", "activeCalories", "totalCalories", "floorsClimbed", "hydration" -> true
+        else -> false
+    }
+
+    private fun aggregateMetricFor(type: String): AggregateMetric<*>? = when (type) {
+        "steps" -> StepsRecord.COUNT_TOTAL
+        "distance" -> DistanceRecord.DISTANCE_TOTAL
+        "activeCalories" -> ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL
+        "totalCalories" -> TotalCaloriesBurnedRecord.ENERGY_TOTAL
+        "floorsClimbed" -> FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL
+        "hydration" -> HydrationRecord.VOLUME_TOTAL
+        else -> null
+    }
+
+    private fun extractAggregateValue(type: String, result: AggregationResult): Double? = when (type) {
+        "steps" -> result[StepsRecord.COUNT_TOTAL]?.toDouble()
+        "distance" -> result[DistanceRecord.DISTANCE_TOTAL]?.inMeters
+        "activeCalories" -> result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
+        "totalCalories" -> result[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inKilocalories
+        "floorsClimbed" -> result[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL]
+        "hydration" -> result[HydrationRecord.VOLUME_TOTAL]?.inLiters
+        else -> null
+    }
+
+    private fun aggregateUnitString(type: String): String = when (type) {
+        "steps", "floorsClimbed" -> "count"
+        "distance" -> "meters"
+        "activeCalories", "totalCalories" -> "kcal"
+        "hydration" -> "liters"
+        else -> "count"
+    }
+
+    private fun aggregateRecord(type: String, value: Double, unit: String, start: Instant, end: Instant): JSONObject =
+        JSONObject().apply {
+            // Aggregated buckets are synthetic and not deduplicable across syncs;
+            // generate an id and a constant "aggregated" source to mirror iOS.
+            put("id", UUID.randomUUID().toString())
+            put("type", type)
+            put("value", value)
+            put("unit", unit)
+            put("startDate", start.toString())
+            put("endDate", end.toString())
+            put("sourceName", "Aggregated")
+            put("sourceId", "aggregated")
+        }
+
+    /**
+     * Aggregate a cumulative metric into interval buckets using Health Connect's
+     * aggregate APIs. Hourly buckets use [HealthConnectClient.aggregateGroupByDuration];
+     * day/week/month buckets use [HealthConnectClient.aggregateGroupByPeriod], which is
+     * calendar-aware. Empty buckets (no data in range) are omitted, matching iOS.
+     */
+    private suspend fun readAggregatedData(
+        client: HealthConnectClient,
+        type: String,
+        start: Instant,
+        end: Instant,
+        interval: String
+    ): JSONArray {
+        val metric = aggregateMetricFor(type)
+            ?: return JSONArray()
+        val unit = aggregateUnitString(type)
+        val results = JSONArray()
+
+        if (interval == "hour") {
+            val response = client.aggregateGroupByDuration(
+                AggregateGroupByDurationRequest(
+                    metrics = setOf(metric),
+                    timeRangeFilter = TimeRangeFilter.between(start, end),
+                    timeRangeSlicer = Duration.ofHours(1)
+                )
+            )
+            response.forEach { bucket ->
+                val value = extractAggregateValue(type, bucket.result) ?: return@forEach
+                results.put(aggregateRecord(type, value, unit, bucket.startTime, bucket.endTime))
+            }
+        } else {
+            val period = when (interval) {
+                "week" -> Period.ofWeeks(1)
+                "month" -> Period.ofMonths(1)
+                else -> Period.ofDays(1)
+            }
+            val zone = ZoneId.systemDefault()
+            val response = client.aggregateGroupByPeriod(
+                AggregateGroupByPeriodRequest(
+                    metrics = setOf(metric),
+                    timeRangeFilter = TimeRangeFilter.between(
+                        LocalDateTime.ofInstant(start, zone),
+                        LocalDateTime.ofInstant(end, zone)
+                    ),
+                    timeRangeSlicer = period
+                )
+            )
+            response.forEach { bucket ->
+                val value = extractAggregateValue(type, bucket.result) ?: return@forEach
+                results.put(
+                    aggregateRecord(
+                        type,
+                        value,
+                        unit,
+                        bucket.startTime.atZone(zone).toInstant(),
+                        bucket.endTime.atZone(zone).toInstant()
+                    )
+                )
+            }
+        }
+        return results
     }
 
     // Read methods

--- a/ios/HealthKits.swift
+++ b/ios/HealthKits.swift
@@ -136,6 +136,10 @@ class HealthKits: RCTEventEmitter {
         } else if typeString == "workout" {
             readWorkoutData(startDate: startDate, endDate: endDate, limit: limit, resolve: resolve, reject: reject)
         } else if aggregate {
+            guard isCumulativeType(typeString) else {
+                reject("UNSUPPORTED_DATA_TYPE", "Aggregation is only supported for cumulative types (steps, distance, activeCalories, totalCalories, floorsClimbed, hydration). '\(typeString)' is not a cumulative type; read raw records and aggregate in app code, or omit `aggregate`.", nil)
+                return
+            }
             let interval = options["aggregateInterval"] as? String ?? "day"
             readAggregatedData(type: typeString, startDate: startDate, endDate: endDate, interval: interval, resolve: resolve, reject: reject)
         } else {
@@ -276,6 +280,18 @@ class HealthKits: RCTEventEmitter {
     
     private func getHKSampleType(for typeString: String) -> HKSampleType? {
         return getHKObjectType(for: typeString) as? HKSampleType
+    }
+
+    /// Aggregation (cumulative sum per interval) only has a well-defined meaning
+    /// for cumulative quantity types. Instantaneous types (heart rate, weight,
+    /// blood glucose, etc.) must be read as raw records instead.
+    private func isCumulativeType(_ typeString: String) -> Bool {
+        switch typeString {
+        case "steps", "distance", "activeCalories", "totalCalories", "floorsClimbed", "hydration":
+            return true
+        default:
+            return false
+        }
     }
     
     private func getHKUnit(for typeString: String) -> HKUnit {

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,21 @@ export type WorkoutType =
   | 'other';
 
 /**
+ * Cumulative data types that support aggregation.
+ *
+ * Aggregation produces a cumulative sum per interval, which only has a
+ * well-defined meaning for these types. Requesting aggregation for any other
+ * (instantaneous) type rejects with `UNSUPPORTED_DATA_TYPE`.
+ */
+export type CumulativeDataType =
+  | 'steps'
+  | 'distance'
+  | 'activeCalories'
+  | 'totalCalories'
+  | 'floorsClimbed'
+  | 'hydration';
+
+/**
  * Options for reading health data
  */
 export interface ReadOptions {
@@ -156,11 +171,23 @@ export interface ReadOptions {
   startDate: Date | string;
   /** End date for the query (ISO 8601 string or Date) */
   endDate: Date | string;
-  /** Maximum number of records to return */
+  /** Maximum number of records to return (ignored when `aggregate` is true) */
   limit?: number;
-  /** Whether to aggregate data (for quantity types) */
+  /**
+   * Aggregate into a cumulative sum per interval.
+   *
+   * Supported only for {@link CumulativeDataType} (steps, distance,
+   * activeCalories, totalCalories, floorsClimbed, hydration) on both iOS and
+   * Android. Requesting it for any other type rejects with
+   * `UNSUPPORTED_DATA_TYPE` — read those as raw records and aggregate in app
+   * code instead.
+   *
+   * Aggregated results are derived/synthetic: they have generated `id`s and an
+   * `"aggregated"` source, so they are not stable or deduplicable. For
+   * sync/storage, persist raw records instead and aggregate at read time.
+   */
   aggregate?: boolean;
-  /** Aggregation interval when aggregate is true */
+  /** Aggregation interval when `aggregate` is true. Defaults to `'day'`. */
   aggregateInterval?: 'hour' | 'day' | 'week' | 'month';
 }
 


### PR DESCRIPTION
Brings Android `readData` aggregation to parity with iOS and tightens the contract on both platforms.

## Problem
`ReadOptions.aggregate` / `aggregateInterval` worked on iOS (`HKStatisticsCollectionQuery`) but Android silently ignored them and always returned raw records — a silent no-op in a unified API. Separately, iOS applied `.cumulativeSum` to *every* quantity type, producing meaningless results for instantaneous types (heartRate, weight, …).

## Changes
- **Android:** implement aggregation via Health Connect `aggregateGroupByPeriod` (day/week/month, calendar-aware) and `aggregateGroupByDuration` (hour), with the per-record total metrics. Output shape mirrors iOS (synthetic id + `"aggregated"` source).
- **Both platforms:** restrict aggregation to cumulative types (`steps`, `distance`, `activeCalories`, `totalCalories`, `floorsClimbed`, `hydration`); other types now reject with `UNSUPPORTED_DATA_TYPE` instead of returning a bogus sum.
- **Types/README/CHANGELOG:** document the supported set and that aggregated results are synthetic — store raw records for sync, aggregate at read time.