### PR TITLE
chore: rebuild example as an RN 0.76 New-Architecture test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ coverage/
 
 # Turborepo
 .turbo/
+
+# Example app (native projects are generated via scripts/bootstrap-example.sh)
+example/ios/Pods/
+example/android/app/build/
+example/android/.cxx/

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -12,6 +12,8 @@ import {
 import HealthKits, {
   HealthData,
   HealthPermission,
+  HealthKitError,
+  HealthKitErrorCode,
 } from '@mbdayo/react-native-health-kits';
 
 const App = () => {
@@ -19,6 +21,10 @@ const App = () => {
   const [permissionsGranted, setPermissionsGranted] = useState(false);
   const [stepsData, setStepsData] = useState<HealthData[]>([]);
   const [heartRateData, setHeartRateData] = useState<HealthData[]>([]);
+  const [dailySteps, setDailySteps] = useState<HealthData[]>([]);
+  const [aggregateGuardResult, setAggregateGuardResult] = useState<string | null>(
+    null
+  );
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -117,6 +123,52 @@ const App = () => {
     }
   };
 
+  // #8: aggregated read — daily step totals (a cumulative type).
+  const readDailySteps = async () => {
+    setLoading(true);
+    try {
+      const data = await HealthKits.readData({
+        type: 'steps',
+        startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // 30 days
+        endDate: new Date(),
+        aggregate: true,
+        aggregateInterval: 'day',
+      });
+      setDailySteps(data);
+    } catch (error) {
+      Alert.alert('Error', `Failed to read daily steps: ${error}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // #8: aggregating a non-cumulative type must reject with UNSUPPORTED_DATA_TYPE.
+  const testAggregateGuard = async () => {
+    setLoading(true);
+    setAggregateGuardResult(null);
+    try {
+      await HealthKits.readData({
+        type: 'heartRate',
+        startDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        endDate: new Date(),
+        aggregate: true,
+        aggregateInterval: 'day',
+      });
+      setAggregateGuardResult('❌ Expected a rejection, but the call resolved');
+    } catch (error) {
+      if (
+        error instanceof HealthKitError &&
+        error.code === HealthKitErrorCode.UNSUPPORTED_DATA_TYPE
+      ) {
+        setAggregateGuardResult('✅ Rejected with UNSUPPORTED_DATA_TYPE (correct)');
+      } else {
+        setAggregateGuardResult(`⚠️ Rejected with an unexpected error: ${error}`);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const openSettings = async () => {
     if (Platform.OS === 'android') {
       await HealthKits.openHealthConnectSettings();
@@ -208,6 +260,51 @@ const App = () => {
                   {'value' in record ? `${record.value} bpm` : '-'}
                 </Text>
               ))}
+            </View>
+          )}
+        </View>
+
+        {/* Aggregated Steps (#8) */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Daily Step Totals (Last 30 Days)</Text>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={readDailySteps}
+            disabled={loading || !permissionsGranted}
+          >
+            <Text style={styles.buttonText}>Read Aggregated (daily)</Text>
+          </TouchableOpacity>
+          {dailySteps.length > 0 && (
+            <View style={styles.dataContainer}>
+              <Text style={styles.dataText}>Buckets: {dailySteps.length}</Text>
+              {dailySteps.slice(0, 5).map((record, index) => (
+                <Text key={index} style={styles.dataText}>
+                  {record.startDate.slice(0, 10)}:{' '}
+                  {'value' in record ? Math.round(record.value as number) : '-'}
+                </Text>
+              ))}
+            </View>
+          )}
+        </View>
+
+        {/* Aggregation Guard (#8) */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Aggregation Guard</Text>
+          <Text style={styles.status}>
+            Aggregating a non-cumulative type (heartRate) should reject.
+          </Text>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={testAggregateGuard}
+            disabled={loading || !permissionsGranted}
+          >
+            <Text style={styles.buttonText}>
+              Test heartRate Aggregate (expect reject)
+            </Text>
+          </TouchableOpacity>
+          {aggregateGuardResult && (
+            <View style={styles.dataContainer}>
+              <Text style={styles.dataText}>{aggregateGuardResult}</Text>
             </View>
           )}
         </View>

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,63 @@
+# Example app
+
+A minimal React Native app for exercising `@mbdayo/react-native-health-kits` on
+a real device. It's the manual test harness for the library.
+
+The JS (`App.tsx`, `package.json`, metro/babel config) is committed; the native
+host projects (`ios/`, `android/`) are machine-generated and **not** committed —
+generate them once with the bootstrap script below.
+
+## Requirements
+
+- React Native 0.76 with the **New Architecture** (this library is a Turbo Native Module)
+- **iOS:** a *physical device* — HealthKit is unavailable in the simulator. Xcode + CocoaPods.
+- **Android:** a device/emulator with **Health Connect** installed (Play Store on Android 9–13; built in on 14+). Android SDK.
+
+## Setup
+
+From the repo root:
+
+```bash
+bash scripts/bootstrap-example.sh
+```
+
+This generates `example/ios` and `example/android` at RN 0.76, sets the iOS
+deployment target to 16.0, adds the HealthKit `Info.plist` keys, enables the New
+Architecture, links the library via the Yarn workspace, and runs `pod install`.
+
+Then, one-time in Xcode: open `example/ios/HealthKitsExample.xcworkspace` →
+target → **Signing & Capabilities** → add the **HealthKit** capability and select
+a signing team.
+
+> The Health Connect permissions and the permissions-rationale activity are
+> declared in the library's own `AndroidManifest.xml` and merge into the app
+> automatically — no manifest edits needed in the example.
+
+## Run
+
+```bash
+# iOS (physical device only)
+yarn workspace @mbdayo/react-native-health-kits-example ios --device
+
+# Android (device/emulator with Health Connect)
+yarn workspace @mbdayo/react-native-health-kits-example android
+```
+
+## What to verify
+
+**TurboModule registration (#7 / issue #1)**
+- The app launches without `TurboModuleRegistry.getEnforcing('HealthKits') could not be found`.
+- "Health Data Availability" shows ✅ Available. (If it loads at all, the Turbo Native Module resolved.)
+
+**Aggregation parity (#8)**
+- Grant permissions, then **Read Aggregated (daily)** → returns daily step buckets on **both** iOS and Android.
+- **Test heartRate Aggregate (expect reject)** → shows "✅ Rejected with UNSUPPORTED_DATA_TYPE" on both platforms (aggregation is cumulative-types-only).
+
+**Basics**
+- Read Steps / Read Heart Rate return records; Write Weight succeeds.
+
+## Troubleshooting
+
+- **`getEnforcing(...) could not be found`** — see the root README's troubleshooting section. Almost always: New Architecture off, or the app wasn't natively rebuilt after install.
+- **iOS: no HealthKit data** — you're on the simulator; use a physical device.
+- **Android: `isAvailable()` is false** — Health Connect isn't installed, or (Android ≤13) the app may need a `<queries>` entry for `com.google.android.apps.healthdata`.

--- a/example/package.json
+++ b/example/package.json
@@ -5,19 +5,21 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start"
+    "start": "react-native start",
+    "pods": "cd ios && RCT_NEW_ARCH_ENABLED=1 pod install"
   },
   "dependencies": {
-    "react": "18.2.0",
-    "react-native": "0.73.0"
+    "@mbdayo/react-native-health-kits": "link:..",
+    "react": "18.3.1",
+    "react-native": "0.76.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.0",
-    "@babel/preset-env": "^7.23.0",
-    "@babel/runtime": "^7.23.0",
-    "@react-native/babel-preset": "0.73.0",
-    "@react-native/metro-config": "0.73.0",
-    "@react-native/typescript-config": "0.73.0",
+    "@babel/core": "^7.25.0",
+    "@babel/preset-env": "^7.25.0",
+    "@babel/runtime": "^7.25.0",
+    "@react-native/babel-preset": "0.76.6",
+    "@react-native/metro-config": "0.76.6",
+    "@react-native/typescript-config": "0.76.6",
     "@types/react": "^18.2.0",
     "typescript": "^5.2.2"
   }

--- a/scripts/bootstrap-example.sh
+++ b/scripts/bootstrap-example.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Generates the native iOS/Android host projects for the example app.
+#
+# The example app's JS (App.tsx, package.json, metro/babel config) lives in the
+# repo, but the native projects (example/ios, example/android) are machine-
+# generated and not committed. Run this once after cloning to produce them.
+#
+# Requirements: Node, Yarn, Xcode + CocoaPods (iOS), Android SDK (Android),
+# and network access. Run from the repo root: `bash scripts/bootstrap-example.sh`
+#
+set -euo pipefail
+
+RN_VERSION="${RN_VERSION:-0.76.6}"
+APP_NAME="HealthKitsExample"   # must match example/app.json "name"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXAMPLE_DIR="$REPO_ROOT/example"
+TMP_DIR="$(mktemp -d)"
+
+echo "▸ Repo root:    $REPO_ROOT"
+echo "▸ RN version:   $RN_VERSION"
+
+if [[ -d "$EXAMPLE_DIR/ios" || -d "$EXAMPLE_DIR/android" ]]; then
+  echo "✗ example/ios or example/android already exists. Remove them first if you want to regenerate." >&2
+  exit 1
+fi
+
+echo "▸ Generating a throwaway RN $RN_VERSION app to harvest native projects…"
+npx @react-native-community/cli@latest init "$APP_NAME" \
+  --directory "$TMP_DIR/app" \
+  --version "$RN_VERSION" \
+  --skip-install \
+  --pm yarn
+
+echo "▸ Copying native projects into example/…"
+cp -R "$TMP_DIR/app/ios" "$EXAMPLE_DIR/ios"
+cp -R "$TMP_DIR/app/android" "$EXAMPLE_DIR/android"
+rm -rf "$TMP_DIR"
+
+# --- iOS: raise deployment target to 16.0 (the library requires it) ---
+PODFILE="$EXAMPLE_DIR/ios/Podfile"
+if [[ -f "$PODFILE" ]]; then
+  echo "▸ Setting iOS Podfile platform to 16.0…"
+  sed -i.bak -E "s/^platform :ios.*/platform :ios, '16.0'/" "$PODFILE" && rm -f "$PODFILE.bak"
+fi
+
+# --- iOS: add HealthKit Info.plist usage descriptions ---
+PLIST="$EXAMPLE_DIR/ios/$APP_NAME/Info.plist"
+if [[ -f "$PLIST" ]]; then
+  echo "▸ Adding HealthKit usage descriptions to Info.plist…"
+  /usr/libexec/PlistBuddy -c \
+    "Add :NSHealthShareUsageDescription string 'Read your health data to display fitness information.'" \
+    "$PLIST" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c \
+    "Add :NSHealthUpdateUsageDescription string 'Write health data on your behalf.'" \
+    "$PLIST" 2>/dev/null || true
+fi
+
+# --- Android: ensure the New Architecture is on (default in 0.76, but be safe) ---
+GRADLE_PROPS="$EXAMPLE_DIR/android/gradle.properties"
+if [[ -f "$GRADLE_PROPS" ]]; then
+  echo "▸ Ensuring newArchEnabled=true…"
+  if grep -q "^newArchEnabled=" "$GRADLE_PROPS"; then
+    sed -i.bak -E "s/^newArchEnabled=.*/newArchEnabled=true/" "$GRADLE_PROPS" && rm -f "$GRADLE_PROPS.bak"
+  else
+    printf "\nnewArchEnabled=true\n" >> "$GRADLE_PROPS"
+  fi
+fi
+
+echo "▸ Installing workspace dependencies (links the library into example/)…"
+( cd "$REPO_ROOT" && yarn install )
+
+echo "▸ Installing iOS pods (New Architecture)…"
+( cd "$EXAMPLE_DIR/ios" && RCT_NEW_ARCH_ENABLED=1 pod install )
+
+cat <<'DONE'
+
+✅ Native projects generated.
+
+Remaining MANUAL steps (one-time):
+  • iOS HealthKit capability: open example/ios/HealthKitsExample.xcworkspace in
+    Xcode → target → Signing & Capabilities → "+ Capability" → HealthKit.
+    Select a development team for signing (HealthKit needs a real device).
+
+Run it:
+  • iOS (physical device only — HealthKit is not on the simulator):
+        yarn workspace @mbdayo/react-native-health-kits-example ios --device
+  • Android (device/emulator with Health Connect installed):
+        yarn workspace @mbdayo/react-native-health-kits-example android
+
+DONE


### PR DESCRIPTION
The `example/` app was incomplete — JS files only (no `ios/`/`android/`), pinned to RN 0.73 (old architecture), and it did not even depend on the library. So it could neither build nor validate the New-Architecture TurboModule work. This makes it a real, buildable manual test harness.

## Changes
- **`example/package.json`:** RN **0.76** (New Architecture by default) + react 18.3.1 + matching toolchain; declares the library via `"@mbdayo/react-native-health-kits": "link:.."` so both native autolinking and Metro resolve it.
- **`example/App.tsx`:** adds an aggregated daily-steps read and an "aggregation guard" test that asserts `heartRate` aggregation rejects with `UNSUPPORTED_DATA_TYPE` (validates #8). Existing availability/permissions/read/write cards retained.
- **`scripts/bootstrap-example.sh`:** generates the `ios/`/`android/` host projects, sets the iOS 16 Podfile platform + HealthKit `Info.plist` keys, enables the New Architecture, links the workspace, and runs `pod install`.
- **`example/README.md`:** setup + per-PR (#7/#8) verification steps and troubleshooting.
- **`.gitignore`:** excludes generated native build artifacts.

## Why a script instead of committed native projects
The `ios/`/`android/` host projects are machine-generated; they are produced locally via the bootstrap script rather than committed. After running it you can choose to commit them so contributors skip the step.

## How to use
```bash
bash scripts/bootstrap-example.sh
# then, one-time in Xcode: add the HealthKit capability + signing team
yarn workspace @mbdayo/react-native-health-kits-example ios --device     # physical device
yarn workspace @mbdayo/react-native-health-kits-example android          # Health Connect installed
```

Note: iOS requires a **physical device** (HealthKit isn't on the simulator) and Android requires **Health Connect** installed.

This is the harness for verifying #7 (TurboModule loads) and #8 (aggregation parity + guard).